### PR TITLE
Add S3 backup storage provider and integration tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.go]
+indent_size = tab
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env and fill in the credentials to run the S3 integration test
+TEST_S3_ENDPOINT=
+TEST_S3_BUCKET=
+TEST_S3_REGION=
+TEST_S3_ACCESS_KEY_ID=
+TEST_S3_SECRET_ACCESS_KEY=
+TEST_S3_USE_TLS=true
+TEST_S3_FORCE_PATH_STYLE=true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,4 +17,12 @@ jobs:
           go-version: '1.25'
 
       - name: Run tests
+        env:
+          TEST_S3_ENDPOINT: ${{ secrets.TEST_S3_ENDPOINT }}
+          TEST_S3_BUCKET: ${{ secrets.TEST_S3_BUCKET }}
+          TEST_S3_REGION: ${{ secrets.TEST_S3_REGION }}
+          TEST_S3_ACCESS_KEY_ID: ${{ secrets.TEST_S3_ACCESS_KEY_ID }}
+          TEST_S3_SECRET_ACCESS_KEY: ${{ secrets.TEST_S3_SECRET_ACCESS_KEY }}
+          TEST_S3_USE_TLS: ${{ secrets.TEST_S3_USE_TLS }}
+          TEST_S3_FORCE_PATH_STYLE: ${{ secrets.TEST_S3_FORCE_PATH_STYLE }}
         run: go test ./... ./test/...

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 **/venv
 **/env
 **/.env*
+!.env.example
 conn.yml
 
 env.yml

--- a/README.md
+++ b/README.md
@@ -45,21 +45,59 @@ A complete example is available in [`compose.example.yaml`](compose.example.yaml
 
 ## Environment Variables
 
+### General settings
+
 | Variable | Description |
 | --- | --- |
+| `BACKUP_TARGET` | Storage provider used for backups. Set to `local` (default) or `s3`. |
 | `DATABASE_LIST` | Comma-separated list of database service identifiers that the controller manages. |
-| `<SERVICE>_POSTGRES_USER` | Username for the target database (defaults to `postgres`). |
-| `<SERVICE>_POSTGRES_PASSWORD` | Password for the target database (defaults to `postgres`). |
-| `<SERVICE>_POSTGRES_DB` | Database name used for restores (defaults to `postgres`). |
-| `<SERVICE>_POSTGRES_HOST` | Hostname of the database service (defaults to the service name). |
 | `MODE` | Set to `production` to use the predefined `/var/lib/postgresql/backup/*` locations and enable scheduled dumps. |
 | `SERVER` | When set to `production`, shared directories are created during initialisation. |
 | `COPING_TO_SHARED` | When `true`, automated dumps triggered in production are also copied to the shared directory. |
 | `TZ` | Optional timezone used by cron-like scheduling inside the container. |
 
+### Database connection overrides
+
+| Variable | Description |
+| --- | --- |
+| `<SERVICE>_POSTGRES_HOST` | Hostname of the database service (defaults to the service name). |
+| `<SERVICE>_POSTGRES_USER` | Username for the target database (defaults to `postgres`). |
+| `<SERVICE>_POSTGRES_PASSWORD` | Password for the target database (defaults to `postgres`). |
+| `<SERVICE>_POSTGRES_DB` | Database name used for restores (defaults to `postgres`). |
+
 > **Note**: Environment variable prefixes are derived from the service identifier in
 > `DATABASE_LIST`. For example, a service named `users` uses `USERS_POSTGRES_USER`,
 > `USERS_POSTGRES_PASSWORD`, etc. Hyphens (`-`) in service names are converted to underscores.
+
+### S3 storage options
+
+| Variable | Description |
+| --- | --- |
+| `S3_BUCKET` | Bucket name used when `BACKUP_TARGET=s3`. |
+| `S3_PREFIX` | Optional prefix inside the S3 bucket where backups are stored. |
+| `S3_REGION` | AWS region of the S3 endpoint. |
+| `S3_ENDPOINT` | Endpoint URL of the S3-compatible service. |
+| `S3_ACCESS_KEY_ID` | Access key for the S3 service. |
+| `S3_SECRET_ACCESS_KEY` | Secret key for the S3 service. |
+| `S3_USE_TLS` | Set to `true` to use HTTPS (recommended). |
+| `S3_FORCE_PATH_STYLE` | Set to `true` for S3-compatible services that require path-style addressing. |
+
+## S3-compatible storage
+
+Set `BACKUP_TARGET=s3` to store backups in an S3-compatible bucket. The controller will
+upload each dump using the credentials and endpoint supplied via the `S3_*` variables
+listed above. Backups remain fully compatible with all other commands (listing and
+restoring downloads the dump to a temporary location inside the container). When `--shared`
+is specified for a dump, the archive is still copied to the shared directory in addition
+to the S3 upload.
+
+### Integration tests
+
+The integration test suite uses Docker to spin up PostgreSQL and controller containers.
+Tests that exercise S3 storage require credentials supplied through the `TEST_S3_*`
+environment variables. You can create a local `.env` file (ignored by Git) by copying
+`.env.example` and filling in the required values. The test harness automatically loads
+the file when present.
 
 ## Controller CLI
 

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -17,17 +17,27 @@ services:
       - users-database:/var/lib/postgresql/databases/users
       - company-database:/var/lib/postgresql/databases/company
     environment:
-      COPING_TO_SHARED: true
+      BACKUP_TARGET: local
       DATABASE_LIST: "users,content"
+      COPING_TO_SHARED: true
+      TZ: Europe/London
+      USERS_POSTGRES_HOST: users-database
       USERS_POSTGRES_USER: postgres
       USERS_POSTGRES_PASSWORD: postgres
       USERS_POSTGRES_DB: postgres
-      USERS_POSTGRES_HOST: users-database
+      CONTENT_POSTGRES_HOST: content-database
       CONTENT_POSTGRES_USER: postgres
       CONTENT_POSTGRES_PASSWORD: postgres
       CONTENT_POSTGRES_DB: postgres
-      CONTENT_POSTGRES_HOST: content-database
-      TZ: Europe/London
+      # Configure these when using S3 storage
+      # S3_BUCKET: my-backups
+      # S3_PREFIX: project-a/prod
+      # S3_REGION: eu-central-1
+      # S3_ENDPOINT: https://s3.eu-central-1.amazonaws.com
+      # S3_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      # S3_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      # S3_USE_TLS: "true"
+      # S3_FORCE_PATH_STYLE: "false"
     user: postgres
     deploy:
       replicas: 1

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -1,0 +1,379 @@
+package s3client
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	Endpoint        string
+	Region          string
+	AccessKeyID     string
+	SecretAccessKey string
+	ForcePathStyle  bool
+	UseTLS          bool
+	Timeout         time.Duration
+}
+
+type Client struct {
+	httpClient      *http.Client
+	endpoint        *url.URL
+	region          string
+	accessKeyID     string
+	secretAccessKey string
+	forcePathStyle  bool
+}
+
+type ListObject struct {
+	Key          string
+	LastModified time.Time
+}
+
+type ListObjectsV2Output struct {
+	Objects               []ListObject
+	IsTruncated           bool
+	NextContinuationToken string
+}
+
+func New(cfg Config) (*Client, error) {
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("endpoint is required")
+	}
+	if cfg.Region == "" {
+		return nil, fmt.Errorf("region is required")
+	}
+	if cfg.AccessKeyID == "" || cfg.SecretAccessKey == "" {
+		return nil, fmt.Errorf("access key credentials are required")
+	}
+	endpoint, err := url.Parse(cfg.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	if endpoint.Scheme == "" {
+		if cfg.UseTLS {
+			endpoint.Scheme = "https"
+		} else {
+			endpoint.Scheme = "http"
+		}
+	}
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/")
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	return &Client{
+		httpClient:      &http.Client{Timeout: timeout},
+		endpoint:        endpoint,
+		region:          cfg.Region,
+		accessKeyID:     cfg.AccessKeyID,
+		secretAccessKey: cfg.SecretAccessKey,
+		forcePathStyle:  cfg.ForcePathStyle,
+	}, nil
+}
+
+func (c *Client) PutObject(ctx context.Context, bucket, key string, body io.ReadSeeker) error {
+	if body == nil {
+		return fmt.Errorf("body is required")
+	}
+	payloadHash, length, err := hashAndLength(body)
+	if err != nil {
+		return err
+	}
+	if _, err := body.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	req, err := c.newRequest(ctx, http.MethodPut, bucket, key, nil, payloadHash, body)
+	if err != nil {
+		return err
+	}
+	req.ContentLength = length
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", length))
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return httpError(resp)
+	}
+	return nil
+}
+
+func (c *Client) GetObject(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, bucket, key, nil, emptyHash(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		return nil, httpError(resp)
+	}
+	return resp.Body, nil
+}
+
+func (c *Client) DeleteObject(ctx context.Context, bucket, key string) error {
+	req, err := c.newRequest(ctx, http.MethodDelete, bucket, key, nil, emptyHash(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return httpError(resp)
+	}
+	return nil
+}
+
+func (c *Client) ListObjectsV2(ctx context.Context, bucket, prefix, continuationToken string) (ListObjectsV2Output, error) {
+	query := url.Values{}
+	query.Set("list-type", "2")
+	if prefix != "" {
+		query.Set("prefix", prefix)
+	}
+	if continuationToken != "" {
+		query.Set("continuation-token", continuationToken)
+	}
+	req, err := c.newRequest(ctx, http.MethodGet, bucket, "", query, emptyHash(), nil)
+	if err != nil {
+		return ListObjectsV2Output{}, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return ListObjectsV2Output{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return ListObjectsV2Output{}, httpError(resp)
+	}
+	var result listBucketResult
+	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ListObjectsV2Output{}, fmt.Errorf("decode list response: %w", err)
+	}
+	objects := make([]ListObject, 0, len(result.Contents))
+	for _, item := range result.Contents {
+		t, err := time.Parse(time.RFC3339, item.LastModified)
+		if err != nil {
+			t = time.Time{}
+		}
+		objects = append(objects, ListObject{Key: item.Key, LastModified: t})
+	}
+	return ListObjectsV2Output{
+		Objects:               objects,
+		IsTruncated:           result.IsTruncated == "true",
+		NextContinuationToken: result.NextContinuationToken,
+	}, nil
+}
+
+type listBucketResult struct {
+	XMLName               xml.Name      `xml:"ListBucketResult"`
+	Contents              []objectEntry `xml:"Contents"`
+	IsTruncated           string        `xml:"IsTruncated"`
+	NextContinuationToken string        `xml:"NextContinuationToken"`
+}
+
+type objectEntry struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+}
+
+func (c *Client) newRequest(ctx context.Context, method, bucket, key string, query url.Values, payloadHash string, body io.Reader) (*http.Request, error) {
+	endpoint := *c.endpoint
+	host := endpoint.Host
+	canonicalKey := strings.TrimPrefix(key, "/")
+	path := "/"
+	if c.forcePathStyle {
+		path += bucket
+		if canonicalKey != "" {
+			path += "/" + canonicalKey
+		}
+	} else {
+		if bucket == "" {
+			return nil, fmt.Errorf("bucket is required")
+		}
+		host = hostWithBucket(bucket, host)
+		if canonicalKey != "" {
+			path += canonicalKey
+		}
+	}
+	canonicalURI := buildCanonicalPath(c.forcePathStyle, bucket, canonicalKey)
+	unescapedPath, err := url.PathUnescape(canonicalURI)
+	if err != nil {
+		return nil, fmt.Errorf("unescape path: %w", err)
+	}
+	endpoint.Host = host
+	endpoint.Path = unescapedPath
+	endpoint.RawPath = canonicalURI
+	if query != nil {
+		endpoint.RawQuery = buildCanonicalQuery(query)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Host = host
+	timestamp := time.Now().UTC()
+	amzDate := timestamp.Format("20060102T150405Z")
+	dateStamp := timestamp.Format("20060102")
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHash)
+	canonicalHeaders := buildCanonicalHeaders(host, payloadHash, amzDate)
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", dateStamp, c.region)
+	canonicalRequest := strings.Join([]string{
+		method,
+		canonicalURI,
+		canonicalQueryString(query),
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		credentialScope,
+		hex.EncodeToString(sha256Sum([]byte(canonicalRequest))),
+	}, "\n")
+	signingKey := c.signingKey(dateStamp)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+	authorization := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s", c.accessKeyID, credentialScope, signedHeaders, signature)
+	req.Header.Set("Authorization", authorization)
+	return req, nil
+}
+
+func buildCanonicalHeaders(host, payloadHash, amzDate string) string {
+	return fmt.Sprintf("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n", strings.ToLower(host), payloadHash, amzDate)
+}
+
+func canonicalQueryString(query url.Values) string {
+	if query == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(query))
+	for key := range query {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var parts []string
+	for _, key := range keys {
+		values := append([]string(nil), query[key]...)
+		sort.Strings(values)
+		for _, value := range values {
+			parts = append(parts, uriEncode(key, true)+"="+uriEncode(value, true))
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+func buildCanonicalQuery(query url.Values) string {
+	if query == nil {
+		return ""
+	}
+	// Canonical query string is already encoded
+	canonical := canonicalQueryString(query)
+	return canonical
+}
+
+func buildCanonicalPath(forcePathStyle bool, bucket, key string) string {
+	var builder strings.Builder
+	builder.WriteString("/")
+	if forcePathStyle {
+		builder.WriteString(uriEncode(bucket, false))
+		if key != "" {
+			builder.WriteString("/")
+		}
+	}
+	if key != "" {
+		segments := strings.Split(key, "/")
+		for i, segment := range segments {
+			builder.WriteString(uriEncode(segment, false))
+			if i < len(segments)-1 {
+				builder.WriteString("/")
+			}
+		}
+	}
+	return builder.String()
+}
+
+func uriEncode(input string, encodeSlash bool) string {
+	var buf strings.Builder
+	for i := 0; i < len(input); i++ {
+		b := input[i]
+		if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '-' || b == '_' || b == '.' || b == '~' {
+			buf.WriteByte(b)
+		} else if b == '/' && !encodeSlash {
+			buf.WriteByte('/')
+		} else {
+			buf.WriteString(fmt.Sprintf("%%%02X", b))
+		}
+	}
+	return buf.String()
+}
+
+func hashAndLength(body io.ReadSeeker) (string, int64, error) {
+	if _, err := body.Seek(0, io.SeekStart); err != nil {
+		return "", 0, err
+	}
+	hash := sha256.New()
+	n, err := io.Copy(hash, body)
+	if err != nil {
+		return "", 0, err
+	}
+	if _, err := body.Seek(0, io.SeekStart); err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), n, nil
+}
+
+func emptyHash() string {
+	h := sha256.Sum256([]byte{})
+	return hex.EncodeToString(h[:])
+}
+
+func sha256Sum(data []byte) []byte {
+	sum := sha256.Sum256(data)
+	return sum[:]
+}
+
+func hmacSHA256(key []byte, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func (c *Client) signingKey(date string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+c.secretAccessKey), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(c.region))
+	kService := hmacSHA256(kRegion, []byte("s3"))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+func hostWithBucket(bucket, endpointHost string) string {
+	if strings.Contains(endpointHost, ":") {
+		parts := strings.Split(endpointHost, ":")
+		return fmt.Sprintf("%s.%s:%s", bucket, parts[0], parts[1])
+	}
+	return fmt.Sprintf("%s.%s", bucket, endpointHost)
+}
+
+func httpError(resp *http.Response) error {
+	data, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("s3 request failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(bytes.TrimSpace(data))))
+}

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"docker-postgres-backuper/storage"
 	"docker-postgres-backuper/utils"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -32,8 +34,25 @@ func main() {
 		sharedPath = utils.BaseSharedDirectoryPath
 	}
 
+	provider, err := storage.NewProvider(os.Getenv("BACKUP_TARGET"), storage.Config{
+		Local: storage.LocalConfig{BasePath: backupPath},
+		S3: storage.S3Config{
+			Bucket:          os.Getenv("S3_BUCKET"),
+			Prefix:          os.Getenv("S3_PREFIX"),
+			Region:          os.Getenv("S3_REGION"),
+			Endpoint:        os.Getenv("S3_ENDPOINT"),
+			AccessKeyID:     os.Getenv("S3_ACCESS_KEY_ID"),
+			SecretAccessKey: os.Getenv("S3_SECRET_ACCESS_KEY"),
+			UseTLS:          boolEnv("S3_USE_TLS", true),
+			ForcePathStyle:  boolEnv("S3_FORCE_PATH_STYLE", false),
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
 	if command == "list" {
-		utils.List(os.Args[2], backupPath)
+		utils.List(provider, os.Args[2])
 		return
 	}
 
@@ -43,27 +62,39 @@ func main() {
 	}
 
 	if command == "restore" {
-		utils.Restore(os.Args[2], backupPath, os.Args[3], []string{})
+		utils.Restore(provider, os.Args[2], os.Args[3], []string{})
 		return
 	}
 
 	if command == "restore-from-shared" {
-		utils.Restore(os.Args[2], sharedPath, "file.dump", databaseList)
+		utils.RestoreFromShared(os.Args[2], sharedPath, "file.dump", databaseList)
 		return
 	}
 
 	if command == "dump" {
-		utils.Dump(os.Args[2], backupPath, "manual", len(os.Args) > 3 && os.Args[3] == "--shared", databaseList)
+		utils.Dump(provider, os.Args[2], "manual", len(os.Args) > 3 && os.Args[3] == "--shared", databaseList, sharedPath)
 		return
 	}
 
-	utils.Initialize(databaseList, backupPath, sharedPath)
+	utils.Initialize(provider, databaseList, sharedPath, os.Getenv("SERVER") == "production")
 
 	fmt.Println("Program started...")
 
 	for range time.Tick(time.Hour) {
 		if time.Now().Hour()%utils.IntervalInHours == 3 && os.Getenv("MODE") == "production" {
-			utils.Dump("--all", backupPath, utils.GetBackupType(), os.Getenv("COPING_TO_SHARED") == "true", databaseList)
+			utils.Dump(provider, "--all", utils.GetBackupType(), os.Getenv("COPING_TO_SHARED") == "true", databaseList, sharedPath)
 		}
 	}
+}
+
+func boolEnv(key string, defaultValue bool) bool {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
 }

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -1,0 +1,42 @@
+package storage
+
+import (
+	"strings"
+	"time"
+)
+
+// Cleanup applies the retention policy shared across providers.
+func Cleanup(p Provider, database string, now time.Time) error {
+	files, err := p.List(database)
+	if err != nil {
+		return err
+	}
+
+	dailyRetention := now.Add(-7 * 24 * time.Hour)
+	weeklyRetention := now.Add(-30 * 24 * time.Hour)
+	monthlyRetention := now.Add(-365 * 24 * time.Hour)
+
+	for _, file := range files {
+		parts := strings.Split(file.Name, "_")
+		if len(parts) < 2 {
+			continue
+		}
+		backupType := parts[1]
+		cutoff := time.Time{}
+		switch backupType {
+		case "daily":
+			cutoff = dailyRetention
+		case "weekly":
+			cutoff = weeklyRetention
+		case "monthly":
+			cutoff = monthlyRetention
+		default:
+			continue
+		}
+		if !file.Modified.IsZero() && file.Modified.Before(cutoff) {
+			_ = p.Delete(database, file.Name)
+		}
+	}
+
+	return nil
+}

--- a/storage/config.go
+++ b/storage/config.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"fmt"
+)
+
+// Config aggregates provider specific configuration.
+type Config struct {
+	Local LocalConfig
+	S3    S3Config
+}
+
+type LocalConfig struct {
+	BasePath string
+}
+
+type S3Config struct {
+	Bucket          string
+	Prefix          string
+	Region          string
+	Endpoint        string
+	AccessKeyID     string
+	SecretAccessKey string
+	UseTLS          bool
+	ForcePathStyle  bool
+}
+
+// NewProvider builds the concrete storage provider based on the requested target.
+func NewProvider(target string, cfg Config) (Provider, error) {
+	switch target {
+	case "", "local":
+		if cfg.Local.BasePath == "" {
+			return nil, fmt.Errorf("local storage requires base path")
+		}
+		return NewLocalProvider(cfg.Local.BasePath), nil
+	case "s3":
+		if cfg.S3.Bucket == "" {
+			return nil, fmt.Errorf("s3 storage requires bucket")
+		}
+		return NewS3Provider(cfg.S3)
+	default:
+		return nil, fmt.Errorf("unsupported backup target: %s", target)
+	}
+}

--- a/storage/local.go
+++ b/storage/local.go
@@ -1,0 +1,96 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type localProvider struct {
+	basePath string
+}
+
+// NewLocalProvider creates a provider that persists backups on the filesystem.
+func NewLocalProvider(basePath string) Provider {
+	return &localProvider{basePath: basePath}
+}
+
+func (p *localProvider) EnsureDatabase(database string) error {
+	return os.MkdirAll(p.databasePath(database), 0o755)
+}
+
+func (p *localProvider) Save(database, filename, localPath string) error {
+	destPath := filepath.Join(p.databasePath(database), filename)
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+	if err := os.Rename(localPath, destPath); err != nil {
+		if err := copyFile(localPath, destPath); err != nil {
+			return err
+		}
+		if err := os.Remove(localPath); err != nil {
+			return fmt.Errorf("remove temporary file: %w", err)
+		}
+		return nil
+	}
+	return nil
+}
+
+func (p *localProvider) List(database string) ([]FileInfo, error) {
+	entries, err := os.ReadDir(p.databasePath(database))
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		fi, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, FileInfo{Name: entry.Name(), Modified: fi.ModTime()})
+	}
+	return infos, nil
+}
+
+func (p *localProvider) Fetch(database, filename string) (string, func() error, error) {
+	path := filepath.Join(p.databasePath(database), filename)
+	if _, err := os.Stat(path); err != nil {
+		return "", nil, err
+	}
+	return path, func() error { return nil }, nil
+}
+
+func (p *localProvider) Delete(database, filename string) error {
+	return os.Remove(filepath.Join(p.databasePath(database), filename))
+}
+
+func (p *localProvider) databasePath(database string) string {
+	return filepath.Join(p.basePath, database)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source file: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create destination file: %w", err)
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy file contents: %w", err)
+	}
+
+	if err := out.Sync(); err != nil {
+		return fmt.Errorf("sync destination file: %w", err)
+	}
+
+	return nil
+}

--- a/storage/provider.go
+++ b/storage/provider.go
@@ -1,0 +1,19 @@
+package storage
+
+import "time"
+
+// FileInfo represents a backup artifact in storage.
+type FileInfo struct {
+	Name     string
+	Modified time.Time
+}
+
+// Provider describes the capabilities required by the controller to
+// persist and retrieve backups.
+type Provider interface {
+	EnsureDatabase(database string) error
+	Save(database, filename, localPath string) error
+	List(database string) ([]FileInfo, error)
+	Fetch(database, filename string) (localPath string, cleanup func() error, err error)
+	Delete(database, filename string) error
+}

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"docker-postgres-backuper/internal/s3client"
+)
+
+type s3Provider struct {
+	client *s3client.Client
+	bucket string
+	prefix string
+}
+
+func NewS3Provider(cfg S3Config) (Provider, error) {
+	client, err := s3client.New(s3client.Config{
+		Endpoint:        cfg.Endpoint,
+		Region:          cfg.Region,
+		AccessKeyID:     cfg.AccessKeyID,
+		SecretAccessKey: cfg.SecretAccessKey,
+		ForcePathStyle:  cfg.ForcePathStyle,
+		UseTLS:          cfg.UseTLS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	normalizedPrefix := strings.Trim(cfg.Prefix, "/")
+	if normalizedPrefix != "" {
+		normalizedPrefix += "/"
+	}
+	return &s3Provider{
+		client: client,
+		bucket: cfg.Bucket,
+		prefix: normalizedPrefix,
+	}, nil
+}
+
+func (p *s3Provider) EnsureDatabase(database string) error {
+	return nil
+}
+
+func (p *s3Provider) Save(database, filename, localPath string) error {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("open local file: %w", err)
+	}
+	defer file.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := p.client.PutObject(ctx, p.bucket, p.objectKey(database, filename), file); err != nil {
+		return fmt.Errorf("upload object: %w", err)
+	}
+	return nil
+}
+
+func (p *s3Provider) List(database string) ([]FileInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	prefix := p.databasePrefix(database)
+	token := ""
+	var files []FileInfo
+	for {
+		output, err := p.client.ListObjectsV2(ctx, p.bucket, prefix, token)
+		if err != nil {
+			return nil, fmt.Errorf("list objects: %w", err)
+		}
+		for _, object := range output.Objects {
+			name := path.Base(object.Key)
+			if name == "" {
+				continue
+			}
+			files = append(files, FileInfo{Name: name, Modified: object.LastModified})
+		}
+		if !output.IsTruncated || output.NextContinuationToken == "" {
+			break
+		}
+		token = output.NextContinuationToken
+	}
+	return files, nil
+}
+
+func (p *s3Provider) Fetch(database, filename string) (string, func() error, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	reader, err := p.client.GetObject(ctx, p.bucket, p.objectKey(database, filename))
+	if err != nil {
+		return "", nil, fmt.Errorf("download object: %w", err)
+	}
+	defer reader.Close()
+	tmp, err := os.CreateTemp("", "s3-backup-*.dump")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp file: %w", err)
+	}
+	if _, err := io.Copy(tmp, reader); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", nil, fmt.Errorf("close temp file: %w", err)
+	}
+	return tmp.Name(), func() error { return os.Remove(tmp.Name()) }, nil
+}
+
+func (p *s3Provider) Delete(database, filename string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := p.client.DeleteObject(ctx, p.bucket, p.objectKey(database, filename)); err != nil {
+		return fmt.Errorf("delete object: %w", err)
+	}
+	return nil
+}
+
+func (p *s3Provider) objectKey(database, filename string) string {
+	return p.databasePrefix(database) + filename
+}
+
+func (p *s3Provider) databasePrefix(database string) string {
+	return fmt.Sprintf("%s%s/", p.prefix, strings.Trim(database, "/"))
+}

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -7,126 +7,217 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"docker-postgres-backuper/internal/s3client"
 )
 
-const dockerCommandTimeout = 5 * time.Minute
+const (
+	dockerCommandTimeout = 5 * time.Minute
+)
 
-func TestControllerEndToEnd(t *testing.T) {
+type controllerTestEnv struct {
+	t            *testing.T
+	repoRoot     string
+	networkName  string
+	postgresName string
+	imageName    string
+}
+
+func newControllerTestEnv(t *testing.T) *controllerTestEnv {
 	requireDocker(t)
 
 	repoRoot := projectRoot(t)
+	env := &controllerTestEnv{t: t, repoRoot: repoRoot}
 
-	networkName := fmt.Sprintf("pgbackup-test-%d", time.Now().UnixNano())
-	t.Logf("creating temporary Docker network %s", networkName)
-	runDockerCommand(t, repoRoot, "network", "create", networkName)
+	env.networkName = fmt.Sprintf("pgbackup-test-%d", time.Now().UnixNano())
+	t.Logf("creating temporary Docker network %s", env.networkName)
+	runDockerCommand(t, repoRoot, "network", "create", env.networkName)
 	t.Cleanup(func() {
-		runDockerCommandAllowFailure(t, repoRoot, "network", "rm", networkName)
+		runDockerCommandAllowFailure(t, repoRoot, "network", "rm", env.networkName)
 	})
 
-	postgresName := networkName + "-postgres"
-	t.Logf("starting postgres container %s", postgresName)
+	env.postgresName = env.networkName + "-postgres"
+	t.Logf("starting postgres container %s", env.postgresName)
 	runDockerCommand(t, repoRoot,
 		"run", "-d",
-		"--name", postgresName,
-		"--network", networkName,
+		"--name", env.postgresName,
+		"--network", env.networkName,
 		"--network-alias", "postgres-db",
 		"-e", "POSTGRES_PASSWORD=postgres",
 		"-e", "POSTGRES_DB=postgres",
 		"postgres:15-alpine",
 	)
 	t.Cleanup(func() {
-		runDockerCommandAllowFailure(t, repoRoot, "rm", "-f", postgresName)
+		runDockerCommandAllowFailure(t, repoRoot, "rm", "-f", env.postgresName)
 	})
 
 	t.Log("waiting for postgres to accept connections")
-	waitForPostgresReady(t, postgresName)
+	waitForPostgresReady(t, env.postgresName)
 
-	runPSQL(t, repoRoot, postgresName, "CREATE TABLE IF NOT EXISTS items (id SERIAL PRIMARY KEY, name TEXT NOT NULL);")
-	runPSQL(t, repoRoot, postgresName, "TRUNCATE items;")
-
-	initialRows := []string{"alpha", "beta"}
-	t.Log("inserting initial dataset into postgres")
-	insertRows(t, repoRoot, postgresName, initialRows)
-
-	imageName := fmt.Sprintf("controller-test:%d", time.Now().UnixNano())
-	t.Logf("building controller image %s", imageName)
+	env.imageName = fmt.Sprintf("controller-test:%d", time.Now().UnixNano())
+	t.Logf("building controller image %s", env.imageName)
 	runDockerCommand(t, repoRoot,
-		"build", "-t", imageName,
+		"build", "-t", env.imageName,
 		"--build-arg", "POSTGRES_VERSION=15",
 		repoRoot,
 	)
 	t.Cleanup(func() {
-		runDockerCommandAllowFailure(t, repoRoot, "rmi", "-f", imageName)
+		runDockerCommandAllowFailure(t, repoRoot, "rmi", "-f", env.imageName)
 	})
 
-	controllerName := networkName + "-controller"
-	t.Logf("starting controller container %s", controllerName)
-	runDockerCommand(t, repoRoot,
+	return env
+}
+
+func (env *controllerTestEnv) startController(envVars map[string]string) string {
+	name := fmt.Sprintf("%s-controller-%d", env.networkName, time.Now().UnixNano())
+	args := []string{
 		"run", "-d",
-		"--name", controllerName,
-		"--network", networkName,
+		"--name", name,
+		"--network", env.networkName,
 		"--network-alias", "controller",
-		"-e", "DATABASE_LIST=testdb",
-		"-e", "TESTDB_POSTGRES_USER=postgres",
-		"-e", "TESTDB_POSTGRES_PASSWORD=postgres",
-		"-e", "TESTDB_POSTGRES_HOST=postgres-db",
-		"-e", "TESTDB_POSTGRES_DB=postgres",
-		"-e", "MODE=production",
-		"-e", "SERVER=production",
+	}
+	for key, value := range envVars {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", key, value))
+	}
+	args = append(args,
 		"--entrypoint", "/bin/sh",
-		imageName,
+		env.imageName,
 		"-c", "tail -f /dev/null",
 	)
-	t.Cleanup(func() {
-		runDockerCommandAllowFailure(t, repoRoot, "rm", "-f", controllerName)
+	runDockerCommand(env.t, env.repoRoot, args...)
+	env.t.Cleanup(func() {
+		runDockerCommandAllowFailure(env.t, env.repoRoot, "rm", "-f", name)
+	})
+	return name
+}
+
+func TestControllerLocalStorage(t *testing.T) {
+	env := newControllerTestEnv(t)
+
+	runPSQL(t, env.repoRoot, env.postgresName, "CREATE TABLE IF NOT EXISTS items (id SERIAL PRIMARY KEY, name TEXT NOT NULL);")
+	runPSQL(t, env.repoRoot, env.postgresName, "TRUNCATE items;")
+
+	initialRows := []string{"alpha", "beta"}
+	t.Log("inserting initial dataset into postgres")
+	insertRows(t, env.repoRoot, env.postgresName, initialRows)
+
+	controllerName := env.startController(map[string]string{
+		"DATABASE_LIST":            "testdb",
+		"TESTDB_POSTGRES_USER":     "postgres",
+		"TESTDB_POSTGRES_PASSWORD": "postgres",
+		"TESTDB_POSTGRES_HOST":     "postgres-db",
+		"TESTDB_POSTGRES_DB":       "postgres",
+		"MODE":                     "production",
+		"SERVER":                   "production",
 	})
 
-	t.Log("preparing backup directories inside controller")
-	createControllerDirectories(t, repoRoot, controllerName)
-
 	t.Log("running manual dump")
-	runController(t, repoRoot, controllerName, "./controller", "dump", "testdb")
+	runController(t, env.repoRoot, controllerName, "./controller", "dump", "testdb")
 
-	backupFile := latestBackup(t, repoRoot, controllerName, "/var/lib/postgresql/backup/data/testdb")
+	backupFile := latestBackup(t, env.repoRoot, controllerName, "/var/lib/postgresql/backup/data/testdb")
 	if !strings.Contains(backupFile, "manual") {
 		t.Fatalf("unexpected backup name: %s", backupFile)
 	}
 
 	t.Log("clearing table to validate restore")
-	runPSQL(t, repoRoot, postgresName, "DELETE FROM items;")
-	if rows := queryRows(t, repoRoot, postgresName); len(rows) != 0 {
+	runPSQL(t, env.repoRoot, env.postgresName, "DELETE FROM items;")
+	if rows := queryRows(t, env.repoRoot, env.postgresName); len(rows) != 0 {
 		t.Fatalf("expected empty table after delete, got %v", rows)
 	}
 
 	t.Logf("restoring dump %s", backupFile)
-	runController(t, repoRoot, controllerName, "./controller", "restore", "testdb", backupFile)
+	runController(t, env.repoRoot, controllerName, "./controller", "restore", "testdb", backupFile)
 
-	if rows := queryRows(t, repoRoot, postgresName); !equalSlices(rows, initialRows) {
+	if rows := queryRows(t, env.repoRoot, env.postgresName); !equalSlices(rows, initialRows) {
 		t.Fatalf("unexpected data after restore: %v", rows)
 	}
 
 	sharedRows := []string{"charlie", "delta"}
 	t.Log("preparing shared dump dataset")
-	runPSQL(t, repoRoot, postgresName, "TRUNCATE items;")
-	insertRows(t, repoRoot, postgresName, sharedRows)
+	runPSQL(t, env.repoRoot, env.postgresName, "TRUNCATE items;")
+	insertRows(t, env.repoRoot, env.postgresName, sharedRows)
 
 	t.Log("creating shared dump")
-	runController(t, repoRoot, controllerName, "./controller", "dump", "testdb", "--shared")
+	runController(t, env.repoRoot, controllerName, "./controller", "dump", "testdb", "--shared")
 
-	ensureSharedDumpExists(t, repoRoot, controllerName, "/var/lib/postgresql/backup/shared/testdb/file.dump")
+	ensureSharedDumpExists(t, env.repoRoot, controllerName, "/var/lib/postgresql/backup/shared/testdb/file.dump")
 
 	t.Log("mutating table before restore-from-shared")
-	runPSQL(t, repoRoot, postgresName, "TRUNCATE items;")
-	insertRows(t, repoRoot, postgresName, []string{"mutated"})
+	runPSQL(t, env.repoRoot, env.postgresName, "TRUNCATE items;")
+	insertRows(t, env.repoRoot, env.postgresName, []string{"mutated"})
 
 	t.Log("restoring from shared dump")
-	runController(t, repoRoot, controllerName, "./controller", "restore-from-shared", "testdb")
+	runController(t, env.repoRoot, controllerName, "./controller", "restore-from-shared", "testdb")
 
-	if rows := queryRows(t, repoRoot, postgresName); !equalSlices(rows, sharedRows) {
+	if rows := queryRows(t, env.repoRoot, env.postgresName); !equalSlices(rows, sharedRows) {
 		t.Fatalf("unexpected data after restore-from-shared: %v", rows)
+	}
+}
+
+func TestControllerS3Storage(t *testing.T) {
+	env := newControllerTestEnv(t)
+
+	cfg, ok := loadS3TestConfig(t)
+	if !ok {
+		t.Skip("skipping S3 storage test: TEST_S3_* variables are not configured")
+	}
+
+	runPSQL(t, env.repoRoot, env.postgresName, "CREATE TABLE IF NOT EXISTS items (id SERIAL PRIMARY KEY, name TEXT NOT NULL);")
+	runPSQL(t, env.repoRoot, env.postgresName, "TRUNCATE items;")
+
+	initialRows := []string{"echo", "foxtrot"}
+	insertRows(t, env.repoRoot, env.postgresName, initialRows)
+
+	prefix := fmt.Sprintf("integration-tests/%d", time.Now().UnixNano())
+	client := newS3Client(t, cfg)
+	cleanup := func() { cleanupS3Prefix(t, client, cfg.Bucket, prefix) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	controllerName := env.startController(map[string]string{
+		"DATABASE_LIST":            "testdb",
+		"TESTDB_POSTGRES_USER":     "postgres",
+		"TESTDB_POSTGRES_PASSWORD": "postgres",
+		"TESTDB_POSTGRES_HOST":     "postgres-db",
+		"TESTDB_POSTGRES_DB":       "postgres",
+		"MODE":                     "production",
+		"SERVER":                   "production",
+		"BACKUP_TARGET":            "s3",
+		"S3_BUCKET":                cfg.Bucket,
+		"S3_PREFIX":                prefix,
+		"S3_REGION":                cfg.Region,
+		"S3_ENDPOINT":              cfg.Endpoint,
+		"S3_ACCESS_KEY_ID":         cfg.AccessKeyID,
+		"S3_SECRET_ACCESS_KEY":     cfg.SecretAccessKey,
+		"S3_USE_TLS":               strconv.FormatBool(cfg.UseTLS),
+		"S3_FORCE_PATH_STYLE":      strconv.FormatBool(cfg.ForcePathStyle),
+	})
+
+	t.Log("running manual dump to s3")
+	runController(t, env.repoRoot, controllerName, "./controller", "dump", "testdb")
+
+	backups := listS3Backups(t, client, cfg.Bucket, prefix, "testdb")
+	if len(backups) == 0 {
+		t.Fatalf("no backups found in s3 for prefix %s", prefix)
+	}
+	sort.Strings(backups)
+	backupFile := backups[len(backups)-1]
+	if !strings.Contains(backupFile, "manual") {
+		t.Fatalf("unexpected backup filename: %s", backupFile)
+	}
+
+	t.Log("clearing table before s3 restore")
+	runPSQL(t, env.repoRoot, env.postgresName, "DELETE FROM items;")
+
+	t.Log("restoring from s3 backup")
+	runController(t, env.repoRoot, controllerName, "./controller", "restore", "testdb", backupFile)
+
+	if rows := queryRows(t, env.repoRoot, env.postgresName); !equalSlices(rows, initialRows) {
+		t.Fatalf("unexpected data after s3 restore: %v", rows)
 	}
 }
 
@@ -214,12 +305,6 @@ func queryRows(t *testing.T, dir, container string) []string {
 	return strings.Split(output, "\n")
 }
 
-func createControllerDirectories(t *testing.T, dir, container string) {
-	t.Helper()
-	runDockerCommand(t, dir, "exec", "-u", "postgres", container, "mkdir", "-p", "/var/lib/postgresql/backup/data/testdb")
-	runDockerCommand(t, dir, "exec", "-u", "postgres", container, "mkdir", "-p", "/var/lib/postgresql/backup/shared/testdb")
-}
-
 func runController(t *testing.T, dir, container string, args ...string) {
 	t.Helper()
 	command := append([]string{"exec", "-u", "postgres", container}, args...)
@@ -252,4 +337,91 @@ func equalSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func newS3Client(t *testing.T, cfg s3TestConfig) *s3client.Client {
+	t.Helper()
+	client, err := s3client.New(s3client.Config{
+		Endpoint:        cfg.Endpoint,
+		Region:          cfg.Region,
+		AccessKeyID:     cfg.AccessKeyID,
+		SecretAccessKey: cfg.SecretAccessKey,
+		ForcePathStyle:  cfg.ForcePathStyle,
+		UseTLS:          cfg.UseTLS,
+	})
+	if err != nil {
+		t.Fatalf("failed to create s3 client: %v", err)
+	}
+	return client
+}
+
+func listS3Backups(t *testing.T, client *s3client.Client, bucket, prefix, database string) []string {
+	t.Helper()
+	keyPrefix := s3KeyPrefix(prefix, database)
+	var results []string
+	token := ""
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		output, err := client.ListObjectsV2(ctx, bucket, keyPrefix, token)
+		cancel()
+		if err != nil {
+			t.Fatalf("list objects: %v", err)
+		}
+		for _, object := range output.Objects {
+			base := pathBase(object.Key)
+			if base == "" {
+				continue
+			}
+			results = append(results, base)
+		}
+		if !output.IsTruncated || output.NextContinuationToken == "" {
+			break
+		}
+		token = output.NextContinuationToken
+	}
+	return results
+}
+
+func cleanupS3Prefix(t *testing.T, client *s3client.Client, bucket, prefix string) {
+	t.Helper()
+	keyPrefix := strings.Trim(prefix, "/")
+	token := ""
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		output, err := client.ListObjectsV2(ctx, bucket, keyPrefix, token)
+		cancel()
+		if err != nil {
+			t.Fatalf("list objects for cleanup: %v", err)
+		}
+		if len(output.Objects) == 0 {
+			break
+		}
+		for _, object := range output.Objects {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if err := client.DeleteObject(ctx, bucket, object.Key); err != nil {
+				cancel()
+				t.Fatalf("delete object: %v", err)
+			}
+			cancel()
+		}
+		if !output.IsTruncated || output.NextContinuationToken == "" {
+			break
+		}
+		token = output.NextContinuationToken
+	}
+}
+
+func s3KeyPrefix(prefix, database string) string {
+	base := strings.Trim(prefix, "/")
+	if base != "" {
+		base += "/"
+	}
+	return fmt.Sprintf("%s%s/", base, strings.Trim(database, "/"))
+}
+
+func pathBase(key string) string {
+	if idx := strings.LastIndex(key, "/"); idx != -1 {
+		return key[idx+1:]
+	}
+	return key
 }

--- a/test/integration/env.go
+++ b/test/integration/env.go
@@ -1,0 +1,133 @@
+package integration
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type s3TestConfig struct {
+	Endpoint        string
+	Bucket          string
+	Region          string
+	AccessKeyID     string
+	SecretAccessKey string
+	UseTLS          bool
+	ForcePathStyle  bool
+}
+
+var (
+	envOnce sync.Once
+	envErr  error
+)
+
+func loadS3TestConfig(t *testing.T) (s3TestConfig, bool) {
+	t.Helper()
+
+	ensureTestEnvLoaded(t)
+
+	cfg := s3TestConfig{
+		Endpoint:        os.Getenv("TEST_S3_ENDPOINT"),
+		Bucket:          os.Getenv("TEST_S3_BUCKET"),
+		Region:          os.Getenv("TEST_S3_REGION"),
+		AccessKeyID:     os.Getenv("TEST_S3_ACCESS_KEY_ID"),
+		SecretAccessKey: os.Getenv("TEST_S3_SECRET_ACCESS_KEY"),
+		UseTLS:          boolFromEnv("TEST_S3_USE_TLS", true),
+		ForcePathStyle:  boolFromEnv("TEST_S3_FORCE_PATH_STYLE", true),
+	}
+
+	missing := make([]string, 0, 5)
+	if cfg.Endpoint == "" {
+		missing = append(missing, "TEST_S3_ENDPOINT")
+	}
+	if cfg.Bucket == "" {
+		missing = append(missing, "TEST_S3_BUCKET")
+	}
+	if cfg.Region == "" {
+		missing = append(missing, "TEST_S3_REGION")
+	}
+	if cfg.AccessKeyID == "" {
+		missing = append(missing, "TEST_S3_ACCESS_KEY_ID")
+	}
+	if cfg.SecretAccessKey == "" {
+		missing = append(missing, "TEST_S3_SECRET_ACCESS_KEY")
+	}
+
+	if len(missing) > 0 {
+		t.Logf("S3 integration test requires %s", strings.Join(missing, ", "))
+		return s3TestConfig{}, false
+	}
+
+	return cfg, true
+}
+
+func ensureTestEnvLoaded(t *testing.T) {
+	t.Helper()
+
+	envOnce.Do(func() {
+		root := projectRoot(t)
+		envErr = loadEnvFile(filepath.Join(root, ".env"))
+	})
+
+	if envErr != nil {
+		t.Fatalf("load .env: %v", envErr)
+	}
+}
+
+func loadEnvFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(line[len("export "):])
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		if len(value) >= 2 {
+			if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
+				(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
+				value = value[1 : len(value)-1]
+			}
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func boolFromEnv(key string, def bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		if parsed, err := strconv.ParseBool(value); err == nil {
+			return parsed
+		}
+	}
+	return def
+}

--- a/utils/init.go
+++ b/utils/init.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"fmt"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"strings"
+
+	"docker-postgres-backuper/storage"
 )
 
 func getDatabaseEnv(database, env string) string {
@@ -18,25 +20,15 @@ func getDatabaseEnv(database, env string) string {
 	return "postgres"
 }
 
-func Initialize(databaseList []string, backupPath, sharedPath string) {
+func Initialize(provider storage.Provider, databaseList []string, sharedPath string, createShared bool) {
 	for _, database := range databaseList {
-		createFolderCommand := exec.Command(
-			"mkdir",
-			backupPath+"/"+database,
-			"-p",
-		)
-		if message, err := createFolderCommand.CombinedOutput(); err != nil {
-			fmt.Println("create directory error:", err, string(message))
+		if err := provider.EnsureDatabase(database); err != nil {
+			fmt.Println("ensure storage for database error:", err)
 		}
 
-		if os.Getenv("SERVER") == "production" {
-			createFolderCommand = exec.Command(
-				"mkdir",
-				sharedPath+"/"+database,
-				"-p",
-			)
-			if message, err := createFolderCommand.CombinedOutput(); err != nil {
-				fmt.Println("create shared directory error:", err, string(message))
+		if createShared {
+			if err := os.MkdirAll(filepath.Join(sharedPath, database), 0o755); err != nil {
+				fmt.Println("create shared directory error:", err)
 			}
 		}
 	}

--- a/utils/list.go
+++ b/utils/list.go
@@ -2,17 +2,23 @@ package utils
 
 import (
 	"log"
-	"os"
+	"sort"
+
+	"docker-postgres-backuper/storage"
 )
 
-func List(database, backupPath string) {
-	files, err := os.ReadDir(backupPath + "/" + database)
+func List(provider storage.Provider, database string) {
+	files, err := provider.List(database)
 	if err != nil {
-		log.Println("read directory error:", err)
+		log.Println("list backups error:", err)
 		return
 	}
 
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name < files[j].Name
+	})
+
 	for _, file := range files {
-		log.Println(file.Name())
+		log.Println(file.Name)
 	}
 }

--- a/utils/restore.go
+++ b/utils/restore.go
@@ -3,9 +3,46 @@ package utils
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
+
+	"docker-postgres-backuper/storage"
 )
 
-func Restore(database, backupPath, filename string, databaseList []string) {
+func Restore(provider storage.Provider, database, filename string, databaseList []string) {
+	list := []string{database}
+	if database == "--all" {
+		list = databaseList
+	}
+
+	for _, item := range list {
+		localPath, cleanup, err := provider.Fetch(item, filename)
+		if err != nil {
+			fmt.Println("fetch backup error:", err)
+			continue
+		}
+
+		dumpCommand := exec.Command(
+			"pg_restore",
+			"-c",
+			"-U", getDatabaseEnv(item, "POSTGRES_USER"),
+			"-h", getDatabaseEnv(item, "POSTGRES_HOST"),
+			"-d", getDatabaseEnv(item, "POSTGRES_DB"),
+			localPath,
+		)
+		dumpCommand.Env = append(dumpCommand.Env, "PGPASSWORD="+getDatabaseEnv(item, "POSTGRES_PASSWORD"))
+		if message, err := dumpCommand.CombinedOutput(); err != nil {
+			fmt.Println("restore backup error:", err, string(message))
+		}
+
+		if cleanup != nil {
+			if err := cleanup(); err != nil {
+				fmt.Println("cleanup temporary file error:", err)
+			}
+		}
+	}
+}
+
+func RestoreFromShared(database, sharedPath, filename string, databaseList []string) {
 	list := []string{database}
 	if database == "--all" {
 		list = databaseList
@@ -18,11 +55,11 @@ func Restore(database, backupPath, filename string, databaseList []string) {
 			"-U", getDatabaseEnv(item, "POSTGRES_USER"),
 			"-h", getDatabaseEnv(item, "POSTGRES_HOST"),
 			"-d", getDatabaseEnv(item, "POSTGRES_DB"),
-			backupPath+"/"+item+"/"+filename,
+			filepath.Join(sharedPath, item, filename),
 		)
 		dumpCommand.Env = append(dumpCommand.Env, "PGPASSWORD="+getDatabaseEnv(item, "POSTGRES_PASSWORD"))
 		if message, err := dumpCommand.CombinedOutput(); err != nil {
-			fmt.Println("restore backup error:", err, string(message))
+			fmt.Println("restore shared backup error:", err, string(message))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- introduce a pluggable storage provider interface with local and S3 implementations
- add an internal S3 client with AWS Signature V4 support and wire it through the controller CLI
- extend documentation, compose example, and integration tests to cover S3 backups

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68e644f665348333a293017e7b8dc1b0