### PR TITLE
Add retention policy for manual backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ restore tasks.
 - **Configurable credentials per service.** Override host, database, user and password
   for each database through environment variables.
 - **Retention policy.** Old archives are cleaned up automatically (daily backups are
-  kept for 7 days, weekly for 30 days and monthly for 365 days).
+  kept for 7 days, weekly for 30 days and monthly/manual for 365 days).
 - **Shared backup replication.** Optional copying of backups into a shared directory
   that can be mounted by other environments (for example to synchronise staging and
   production).
@@ -169,7 +169,7 @@ Integration tests cover the full backup and restore flow by orchestrating
 PostgreSQL and the controller inside Docker containers. To run them locally:
 
 ```bash
-go test ./test/... -v
+go clean -testcache ; go test ./test/... -v
 ```
 
 > **Tip**: run with `-v` to see a step-by-step log of every Docker command that the

--- a/storage/cleanup.go
+++ b/storage/cleanup.go
@@ -15,6 +15,7 @@ func Cleanup(p Provider, database string, now time.Time) error {
 	dailyRetention := now.Add(-7 * 24 * time.Hour)
 	weeklyRetention := now.Add(-30 * 24 * time.Hour)
 	monthlyRetention := now.Add(-365 * 24 * time.Hour)
+	manualRetention := now.Add(-365 * 24 * time.Hour)
 
 	for _, file := range files {
 		parts := strings.Split(file.Name, "_")
@@ -30,6 +31,8 @@ func Cleanup(p Provider, database string, now time.Time) error {
 			cutoff = weeklyRetention
 		case "monthly":
 			cutoff = monthlyRetention
+		case "manual":
+			cutoff = manualRetention
 		default:
 			continue
 		}


### PR DESCRIPTION
## Summary
- extend the storage cleanup routine to prune manual backups older than one year
- document manual backup retention details and the need to clear the Go test cache before running the suite

## Testing
- go clean -testcache
- go test ./test/... -v

------
https://chatgpt.com/codex/tasks/task_e_68e762e12df0833389bbed3bdd185259