### PR TITLE
Polish dump handling after removing shared logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ COPY --from=build /build/main ./controller
 
 RUN chown -R postgres:postgres /app && \
     mkdir -p /var/lib/postgresql/backup/data && \
-    mkdir -p /var/lib/postgresql/backup/shared && \
     mkdir -p /var/lib/postgresql/databases && \
     chown -R postgres:postgres /var/lib/postgresql/backup && \
     chown -R postgres:postgres /var/lib/postgresql/databases

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -2,8 +2,6 @@ version: '3.8'
 
 volumes:
   database-backup:
-  shared-backup:
-
   users-database:
   content-database:
 
@@ -12,14 +10,12 @@ services:
     image: alexbidenko/docker-postgres-backuper:17postgres
     volumes:
       - database-backup:/var/lib/postgresql/backup/data
-      - shared-backup:/var/lib/postgresql/backup/shared
 
       - users-database:/var/lib/postgresql/databases/users
       - company-database:/var/lib/postgresql/databases/company
     environment:
       BACKUP_TARGET: local
       DATABASE_LIST: "users,content"
-      COPING_TO_SHARED: true
       TZ: Europe/London
       USERS_POSTGRES_HOST: users-database
       USERS_POSTGRES_USER: postgres

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,6 +1,5 @@
 package utils
 
 const BaseBackupDirectoryPath = "/var/lib/postgresql/backup/data"
-const BaseSharedDirectoryPath = "/var/lib/postgresql/backup/shared"
 const BaseDatabaseDirectoryPath = "/var/lib/postgresql/databases"
 const IntervalInHours = 6

--- a/utils/init.go
+++ b/utils/init.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"docker-postgres-backuper/storage"
@@ -20,16 +19,10 @@ func getDatabaseEnv(database, env string) string {
 	return "postgres"
 }
 
-func Initialize(provider storage.Provider, databaseList []string, sharedPath string, createShared bool) {
+func Initialize(provider storage.Provider, databaseList []string) {
 	for _, database := range databaseList {
 		if err := provider.EnsureDatabase(database); err != nil {
 			fmt.Println("ensure storage for database error:", err)
-		}
-
-		if createShared {
-			if err := os.MkdirAll(filepath.Join(sharedPath, database), 0o755); err != nil {
-				fmt.Println("create shared directory error:", err)
-			}
 		}
 	}
 }

--- a/utils/restore.go
+++ b/utils/restore.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"os/exec"
-	"path/filepath"
 
 	"docker-postgres-backuper/storage"
 )
@@ -38,28 +37,6 @@ func Restore(provider storage.Provider, database, filename string, databaseList 
 			if err := cleanup(); err != nil {
 				fmt.Println("cleanup temporary file error:", err)
 			}
-		}
-	}
-}
-
-func RestoreFromShared(database, sharedPath, filename string, databaseList []string) {
-	list := []string{database}
-	if database == "--all" {
-		list = databaseList
-	}
-
-	for _, item := range list {
-		dumpCommand := exec.Command(
-			"pg_restore",
-			"-c",
-			"-U", getDatabaseEnv(item, "POSTGRES_USER"),
-			"-h", getDatabaseEnv(item, "POSTGRES_HOST"),
-			"-d", getDatabaseEnv(item, "POSTGRES_DB"),
-			filepath.Join(sharedPath, item, filename),
-		)
-		dumpCommand.Env = append(dumpCommand.Env, "PGPASSWORD="+getDatabaseEnv(item, "POSTGRES_PASSWORD"))
-		if message, err := dumpCommand.CombinedOutput(); err != nil {
-			fmt.Println("restore shared backup error:", err, string(message))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- drop the extra dump command argument validation since the existing CLI guard already enforces the parameter count
- gofmt the controller integration test to restore canonical indentation after removing shared storage coverage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e766db851c83339778614e9e58d389